### PR TITLE
Docs: Fix Props With Different Types

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -22,6 +22,10 @@
       & table tr {
         th, td {
           vertical-align: top;
+
+          code {
+            word-break: break-word;
+          }
         }
 
         th:first-child,
@@ -38,7 +42,7 @@
 
         th:nth-child(3),
         td:nth-child(3) {
-          width: 10%;
+          width: 18%;
         }
 
         th:nth-child(4),

--- a/vuese-generator.js
+++ b/vuese-generator.js
@@ -68,6 +68,10 @@ function generateMarkdown(file) {
 }
 
 function transformData(data = []) {
+  function capitalise(str) {
+    return str.charAt(0).toUpperCase() + str.slice(1)
+  }
+
   data.forEach((prop) => {
     prop.name = prop.name
 
@@ -79,9 +83,9 @@ function transformData(data = []) {
       // Handle multiple types separated by '|'
       // Convert to array to avoid markdown table issues
       if (prop.type.name.indexOf('|') !== -1) {
-        prop.type = prop.type.name.split('|').map((item) => item.trim())
+        prop.type = prop.type.name.split('|').map((item) => capitalise(item.trim()))
       } else {
-        prop.type = prop.type.name
+        prop.type = capitalise(prop.type.name)
       }
     }
 

--- a/vuese-generator.js
+++ b/vuese-generator.js
@@ -76,7 +76,13 @@ function transformData(data = []) {
     }
 
     if (prop.type) {
-      prop.type = prop.type.name
+      // Handle multiple types separated by '|'
+      // Convert to array to avoid markdown table issues
+      if (prop.type.name.indexOf('|') !== -1) {
+        prop.type = prop.type.name.split('|').map((item) => item.trim())
+      } else {
+        prop.type = prop.type.name
+      }
     }
 
     if (prop.defaultValue) {


### PR DESCRIPTION
When the `props` have different types in `array` format, the parser splits those with a pipe (`|`). When the markdown is rendered, the pipes transform into table cells. 
To fix the issue, the multiple types are transformed into an `array` format to render correctly in markdown.

The update can be tested here:
https://akhuoa.github.io/simulationvuer/components/SimulationVuer.html